### PR TITLE
Remove the Unused Option from Run Parameters

### DIFF
--- a/src/fosslight_android/_common.py
+++ b/src/fosslight_android/_common.py
@@ -78,12 +78,6 @@ class AndroidBinary:
     def set_module_name(self, value):
         self.module_name = value
 
-    def set_exclude(self, value):
-        if value:
-            self.exclude = "Exclude"
-        else:
-            self.exclude = ""
-
     def set_notice(self, value):
         self.notice = value
 
@@ -108,15 +102,6 @@ class AndroidBinary:
 
     def set_oss_version(self, value):
         self.oss_version = value
-
-    def set_url(self, value):
-        self.url = value
-
-    def set_homepage(self, value):
-        self.homepage = value
-
-    def set_download_location(self, value):
-        self.download_location = value
 
     def get_print_items(self):
         print_items_txt = []
@@ -186,25 +171,3 @@ def get_comment(default_comment, license_to_notice, notice_value, empty_columns)
     comment = default_comment + comment  # Paste Auto ID comment in front.
 
     return comment
-
-
-def set_value_switch(bin, key, value):
-    switcher = {
-        'BinaryName': bin.set_bin_name,
-        'SourceCodePath': bin.set_source_code_path,
-        'ModuleName': bin.set_module_name,
-        'NOTICE': bin.set_notice,
-        'License': bin.set_license,
-        'mkFilePath': bin.mk_file_path,
-        'tlsh': bin.set_tlsh,
-        'checksum': bin.set_checksum,
-        'OSSName': bin.set_oss_name,
-        'OSSVersion': bin.set_oss_version,
-        'Comment': bin.set_comment
-    }
-    func = switcher.get(key, lambda key: invalid(key))
-    func(value)
-
-
-def invalid(cmd):
-    print('[{}] is invalid'.format(cmd))

--- a/src/fosslight_android/_common.py
+++ b/src/fosslight_android/_common.py
@@ -11,9 +11,6 @@ CONST_NULL = ""
 CONST_TLSH_NULL = "0"
 MODULE_INFO_FILE_NAME = "module-info.json"
 MODULE_TYPE_NAME = "MODULE_NAME"
-MODULE_TYPE_OUTPUT = "MODULE_OUTPUT"
-MODULE_TYPE_INSTALLED = "installed"
-NEED_CHECK_WORD = "(NEED_CHECK)"
 skip_license = ['Other Proprietary License', 'LGE License', 'LGE Proprietary License']
 NOTICE_FILE_NAME = "NOTICE"
 
@@ -59,9 +56,6 @@ class AndroidBinary:
         self.homepage = ""
         self.additional_oss_items = []
         self.is_new_bin = True
-
-    def __del__(self):
-        pass
 
     def set_bin_name(self, value):
         self.bin_name = value

--- a/src/fosslight_android/android_binary_analysis.py
+++ b/src/fosslight_android/android_binary_analysis.py
@@ -89,7 +89,7 @@ meta_lic_files = {}
 def do_multi_process(func, input_list):
     manager = multiprocessing.Manager()
     return_list = manager.list()
-    splited_data = np.array_split(input_list, num_cores)
+    splited_data = np.array_split(input_list, num_cores) #sus
     splited_data = [x.tolist() for x in splited_data]
 
     parmap.map(func, splited_data, return_list, pm_pbar=True,
@@ -763,7 +763,6 @@ def main():
     notice_check_ok = False
     base_binary_txt = ""
     auto_fill_oss_name = True
-    _NOTICE_CHECKLIST_TYPE = False
     analyze_source = False
     path_to_exclude = []
 

--- a/src/fosslight_android/android_binary_analysis.py
+++ b/src/fosslight_android/android_binary_analysis.py
@@ -89,7 +89,7 @@ meta_lic_files = {}
 def do_multi_process(func, input_list):
     manager = multiprocessing.Manager()
     return_list = manager.list()
-    splited_data = np.array_split(input_list, num_cores) #sus
+    splited_data = np.array_split(input_list, num_cores)  # sus
     splited_data = [x.tolist() for x in splited_data]
 
     parmap.map(func, splited_data, return_list, pm_pbar=True,


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Find and remove only declared options implemented in business logic


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## _common.py

### Redundant field
- MODULE_TYPE_OUTPUT
- MODULE_TYPE_INSTALLED
- NEED_CHECK_WORD

### Redundant func
- def __del__(self):
- def set_exclude(self, value)
- def set_url(self, value):
- def set_homepage(self, value):
- def set_download_location(self, value):
- def set_value_switch(bin, key, value):
- def invalid(cmd):

## android_binary_analysis.py

### Redundant field
-  _NOTICE_CHECKLIST_TYPE = False
- concerned: splited_data
