### PR TITLE
Compressing the notice files

### DIFF
--- a/src/fosslight_android/android_binary_analysis.py
+++ b/src/fosslight_android/android_binary_analysis.py
@@ -10,6 +10,8 @@ import os
 import re
 import json
 import logging
+import zipfile
+import shutil
 # Parsing NOTICE
 from bs4 import BeautifulSoup
 import subprocess


### PR DESCRIPTION
## Description
<Compress and move the notice files to output folder>

1. If there is only one notice file, move it directly to the output folder.
    1-1. Add the following message to the log:
           Notice file to upload FOSSLight Hub: {output_path}/notice_to_fosslight_hub_{datetime}.{extension}

2. If there are multiple notice files, compress them into a ZIP file and move it to the output folder.
    2-1. Add the following message to the log:
           Notice file to upload FOSSLight Hub: {output_path}/notice_to_fosslight_hub_{datetime}.zip


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

