### PR TITLE
remove some options

### DIFF
--- a/src/fosslight_android/android_binary_analysis.py
+++ b/src/fosslight_android/android_binary_analysis.py
@@ -30,11 +30,8 @@ from ._util import (
 )
 from .check_package_file import check_packaging_files
 from .check_notice_file import (
-    run_notice_html_checklist,
     find_bin_in_notice,
-    read_notice_file,
-    create_additional_notice,
-    divide_notice_files_by_binary
+    read_notice_file
 )
 from ._binary_db_controller import get_oss_info_from_db
 from ._common import (
@@ -70,7 +67,6 @@ notice_file_list = {}  # Save file list in NOTICE.html
 platform_version = ""  # Android Version. ex- 7.0.0.r1 -> 7.0
 
 # Define Const Variables
-NOTICE_HTML_FILE_NAME = ""
 ANDROID_LOG_FILE_NAME = "android.log"
 num_cores = 1
 now = ""
@@ -334,8 +330,8 @@ def find_notice_value():
     global notice_file_list, final_bin_info
     str_notice_files = ""
 
-    try:
-        notice_file_list, notice_files = read_notice_file(os.path.abspath(build_out_notice_file_path), NOTICE_HTML_FILE_NAME)
+    try:        
+        notice_file_list, notice_files = read_notice_file(os.path.abspath(build_out_notice_file_path))
         if not notice_file_list:
             logger.info(f"Notice file is empty:{notice_files}")
             return
@@ -763,14 +759,11 @@ def find_meta_lic_files():
                         meta_lic_files[key] = lic
 
 
-def main():
-    global android_log_lines, ANDROID_LOG_FILE_NAME, NOTICE_HTML_FILE_NAME, python_script_dir, num_cores, now, logger, final_bin_info
-    find_empty_path = False
-    _create_additial_notice = False
-    notice_check_ok = False
+def main():    
+    global android_log_lines, ANDROID_LOG_FILE_NAME, python_script_dir, num_cores, now, logger, final_bin_info
+    find_empty_path = False    
     base_binary_txt = ""
-    auto_fill_oss_name = True
-    _NOTICE_CHECKLIST_TYPE = False
+    auto_fill_oss_name = True    
     analyze_source = False
     path_to_exclude = []
     RESULT_FILE_EXTENSION = ".xlsx"
@@ -789,17 +782,12 @@ def main():
     parser = argparse.ArgumentParser(description='FOSSLight Android', prog='fosslight_android', add_help=False)
     parser.add_argument('-h', '--help', action='store_true', required=False)
     parser.add_argument('-v', '--version', action='store_true', required=False)
-    parser.add_argument('-s', '--source', type=str, required=False)
-    parser.add_argument('-b', '--binary', type=str, required=False)
-    parser.add_argument('-n', '--notice', type=str, required=False)
-    parser.add_argument('-t', '--toadd', action='store_true', required=False)
-    parser.add_argument('-m', '--more', action='store_true', required=False)
-    parser.add_argument('-c', '--check', type=str, required=False)
+    parser.add_argument('-s', '--source', type=str, required=False)    
+    parser.add_argument('-m', '--more', action='store_true', required=False)    
     parser.add_argument('-a', '--android', type=str, required=False)
     parser.add_argument('-f', '--find', action='store_true', required=False)
     parser.add_argument('-i', '--ignore', action='store_true', required=False)
-    parser.add_argument('-p', '--packaging', type=str, required=False)
-    parser.add_argument('-d', '--divide', type=str, required=False)
+    parser.add_argument('-p', '--packaging', type=str, required=False)    
     parser.add_argument('-r', '--remove', type=str, required=False)
     parser.add_argument('-e', '--exclude', nargs="*", required=False, default=[])
 
@@ -811,17 +799,10 @@ def main():
     if args.source:  # android source path
         os.chdir(args.source)
         android_src_path = args.source
-    if args.binary:  # Base model's binary.txt to exclude
-        base_binary_txt = args.binary
-    if args.notice:
-        NOTICE_HTML_FILE_NAME = args.notice
-    if args.toadd:  # Create needtoadd-notice.html file.
-        _create_additial_notice = True
+    
     if args.more:  # Analyze source mode.
         analyze_source = True
-    if args.check:
-        _NOTICE_CHECKLIST_TYPE = True
-        notice_check_ok = (args.check == "ok" or args.check == "OK")
+            
     if args.android:
         ANDROID_LOG_FILE_NAME = args.android
     if args.find:  # Execute "find" command when source path is not found.
@@ -836,15 +817,9 @@ def main():
     if args.packaging:
         check_packaging_files(args.packaging)
         return
-    if args.divide:
-        divide_notice_files_by_binary(args.divide, python_script_dir, now)
-        return
+    
     if args.remove:  # Remove the inputted list from the binary list.
-        remove_list_file = args.remove
-
-    if _NOTICE_CHECKLIST_TYPE:
-        run_notice_html_checklist(base_binary_txt, notice_check_ok, NOTICE_HTML_FILE_NAME)
-        return
+        remove_list_file = args.remove    
 
     read_success, android_log_lines = read_file(ANDROID_LOG_FILE_NAME)
     if not read_success:
@@ -879,10 +854,7 @@ def main():
                                                   scan_item, HEADER, HIDDEN_HEADER)
     if not success:
         logger.warning(f"Failed to write result to excel:{msg}")
-    result_log["Output FOSSLight Report"] = f"{result_file}"
-
-    if _create_additial_notice:
-        create_additional_notice(final_bin_info, python_script_dir)
+    result_log["Output FOSSLight Report"] = f"{result_file}"    
 
     # Print the result
     result_log["Output Directory"] = python_script_dir

--- a/src/fosslight_android/check_notice_file.py
+++ b/src/fosslight_android/check_notice_file.py
@@ -96,25 +96,22 @@ def find_files_by_extension(path):
     return files
 
 
-def read_notice_file(notice_file_path, notice_html_file):
+def read_notice_file(notice_file_path):
     final_notice_file = {}
     # NOTICE.html need to be skipped the errors related to decode
     encodings = ["latin-1", "utf-8", "utf-16"]
     notice_files = []
+    
+    if os.path.isfile(notice_file_path):
+        notice_files.append(notice_file_path)
+    if notice_file_path.endswith(".html") or notice_file_path.endswith(".xml") or notice_file_path.endswith(".txt"):
+        notice_file_path = os.path.dirname(notice_file_path)
 
-    if notice_html_file != "":
-        notice_files = notice_html_file.split(",")
-    else:
-        if os.path.isfile(notice_file_path):
-            notice_files.append(notice_file_path)
-        if notice_file_path.endswith(".html") or notice_file_path.endswith(".xml") or notice_file_path.endswith(".txt"):
-            notice_file_path = os.path.dirname(notice_file_path)
-
-        if os.path.isdir(notice_file_path):
-            additional_notice_files = find_files_by_extension(notice_file_path)
-            if len(additional_notice_files) > 0:
-                notice_files.extend(additional_notice_files)
-                notice_files = list(set(notice_files))
+    if os.path.isdir(notice_file_path):
+        additional_notice_files = find_files_by_extension(notice_file_path)
+        if len(additional_notice_files) > 0:
+            notice_files.extend(additional_notice_files)
+            notice_files = list(set(notice_files))
 
     for file_name in notice_files:
         file_list = {}


### PR DESCRIPTION
## Description
remove some options
[Option: -b, -n, -c] Check whether binary names are included in NOTICE.html
This is unnecessary because the inclusion of notices can be checked via FL Hub.

[Option: -t] Collect NOTICES for binaries that are not added to NOTICE.html despite being in the source code path
This can be handled using the Supplement feature in FL Hub.

[Option: -d] Split the needtoadd-notice.html file by binary
This can also be achieved using the Supplement feature in FL Hub.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

