### PR TITLE
Remove unnecessary option in help msg

### DIFF
--- a/src/fosslight_android/_help.py
+++ b/src/fosslight_android/_help.py
@@ -21,9 +21,7 @@ _HELP_MESSAGE = """
             -m\t\t\t\t   Analyze the source code for the path where the license could not be found.
             -e <path1> <path2..>\t   Path to exclude from source analysis.
             -p\t\t\t\t   Check files that should not be included in the Packaging file.
-            -f\t\t\t\t   Print result of Find Command for binary that can not find Source Code Path.
-            -t\t\t\t\t   Collect NOTICE for binaries that are not added to NOTICE.html.
-            -d\t\t\t\t   Divide needtoadd-notice.html by binary.
+            -f\t\t\t\t   Print result of Find Command for binary that can not find Source Code Path.            
             -i\t\t\t\t   Disable the function to automatically convert OSS names based on AOSP.
             -r <result.txt>\t\t   result.txt file with a list of binaries to remove."""
 


### PR DESCRIPTION
## Description
Update the help message to reflect the removal of options -b, -n, -c, -t, and -d

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

